### PR TITLE
(Alternative restart cycle) Allow setting a fixed weekday for weekly restarts

### DIFF
--- a/conf/ServerAutoShutdown.conf.dist
+++ b/conf/ServerAutoShutdown.conf.dist
@@ -24,6 +24,15 @@ ServerAutoShutdown.Enabled = 0
 ServerAutoShutdown.EveryDays = 1
 
 #
+#    ServerAutoShutdown.Weekday
+#        Description: If set (0-6, where 0=Sunday, 1=Monday, ... 6=Saturday), the server will restart on this weekday at the configured time.
+#                     Overrides ServerAutoShutdown.EveryDays if set to a valid value.
+#        Default:     -1 (disabled)
+#
+
+ServerAutoShutdown.Weekday = 3
+
+#
 #    ServerAutoShutdown.Time
 #        Description: Time (in HH:MM:SS) - 24 hours format
 #        Default:     04:00:00

--- a/conf/ServerAutoShutdown.conf.dist
+++ b/conf/ServerAutoShutdown.conf.dist
@@ -30,7 +30,7 @@ ServerAutoShutdown.EveryDays = 1
 #        Default:     -1 (disabled)
 #
 
-ServerAutoShutdown.Weekday = 3
+ServerAutoShutdown.Weekday = -1
 
 #
 #    ServerAutoShutdown.Time

--- a/src/ServerAutoShutdown.cpp
+++ b/src/ServerAutoShutdown.cpp
@@ -15,6 +15,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Common.h"
 #include "Config.h"
 #include "Duration.h"
 #include "GameEventMgr.h"
@@ -35,23 +36,23 @@ namespace
     // Scheduler - for update
     TaskScheduler scheduler;
 
-    time_t GetNextResetTime(time_t time, uint32 day, uint8 hour, uint8 minute, uint8 second)
+    time_t GetNextResetTime(time_t time, uint32 restartDays, uint8 restartHour, uint8 restartMinute, uint8 restartSecond)
     {
         tm timeLocal = Acore::Time::TimeBreakdown(time);
-        timeLocal.tm_hour = hour;
-        timeLocal.tm_min = minute;
-        timeLocal.tm_sec = second;
+        timeLocal.tm_hour = restartHour;
+        timeLocal.tm_min = restartMinute;
+        timeLocal.tm_sec = restartSecond;
 
         time_t midnightLocal = mktime(&timeLocal);
 
-        if (day > 1 || midnightLocal <= time)
-            midnightLocal += 86400 * day;
+        if (restartDays > 1 || midnightLocal <= time)
+            midnightLocal += DAY * restartDays;
 
         return midnightLocal;
     }
 
     // Returns the next time_t for the given weekday (0=Sunday, 1=Monday, ..., 6=Saturday) at the given hour/min/sec
-    time_t GetNextWeekdayTime(time_t now, int weekday, uint8 hour, uint8 minute, uint8 second)
+    time_t GetNextWeekdayTime(time_t now, int weekday, uint8 restartHour, uint8 restartMinute, uint8 restartSecond)
     {
         tm timeLocal = Acore::Time::TimeBreakdown(now);
         int currentWeekday = timeLocal.tm_wday;
@@ -59,17 +60,17 @@ namespace
         if (daysUntil == 0)
         {
             // If today, check if the time has already passed
-            if (timeLocal.tm_hour > hour ||
-                (timeLocal.tm_hour == hour && timeLocal.tm_min > minute) ||
-                (timeLocal.tm_hour == hour && timeLocal.tm_min == minute && timeLocal.tm_sec >= second))
+            if (timeLocal.tm_hour > restartHour ||
+                (timeLocal.tm_hour == restartHour && timeLocal.tm_min > restartMinute) ||
+                (timeLocal.tm_hour == restartHour && timeLocal.tm_min == restartMinute && timeLocal.tm_sec >= restartSecond))
             {
                 daysUntil = 7;
             }
         }
         timeLocal.tm_mday += daysUntil;
-        timeLocal.tm_hour = hour;
-        timeLocal.tm_min = minute;
-        timeLocal.tm_sec = second;
+        timeLocal.tm_hour = restartHour;
+        timeLocal.tm_min = restartMinute;
+        timeLocal.tm_sec = restartSecond;
         time_t result = mktime(&timeLocal);
         return result;
     }
@@ -116,45 +117,45 @@ void ServerAutoShutdown::Init()
     }
 
     int weekday = sConfigMgr->GetOption<int>("ServerAutoShutdown.Weekday", -1);
-    uint32 day =  sConfigMgr->GetOption<uint32>("ServerAutoShutdown.EveryDays", 1);
-    uint8 hour = *Acore::StringTo<uint8>(tokens.at(0));
-    uint8 minute = *Acore::StringTo<uint8>(tokens.at(1));
-    uint8 second = *Acore::StringTo<uint8>(tokens.at(2));
+    uint32 restartDays =  sConfigMgr->GetOption<uint32>("ServerAutoShutdown.EveryDays", 1);
+    uint8 restartHour = *Acore::StringTo<uint8>(tokens.at(0));
+    uint8 restartMinute = *Acore::StringTo<uint8>(tokens.at(1));
+    uint8 restartSecond = *Acore::StringTo<uint8>(tokens.at(2));
 
     auto nowTime = time(nullptr);
     uint64 nextResetTime = 0;
 
     if (weekday >= 0 && weekday <= 6)
     {
-        nextResetTime = GetNextWeekdayTime(nowTime, weekday, hour, minute, second);
+        nextResetTime = GetNextWeekdayTime(nowTime, weekday, restartHour, restartMinute, restartSecond);
     }
     else
     {
-        if (day < 1 || day > 365)
+        if (restartDays < 1 || restartDays > 365)
         {
-            LOG_ERROR("module", "> ServerAutoShutdown: Incorrect day in config option 'ServerAutoShutdown.EveryDays' - '{}'", day);
+            LOG_ERROR("module", "> ServerAutoShutdown: Incorrect day in config option 'ServerAutoShutdown.EveryDays' - '{}'", restartDays);
             _isEnableModule = false;
             return;
         }
-        nextResetTime = GetNextResetTime(nowTime, day, hour, minute, second);
+        nextResetTime = GetNextResetTime(nowTime, restartDays, restartHour, restartMinute, restartSecond);
     }
 
-    if (day < 1 || day > 365)
+    if (restartDays < 1 || restartDays > 365)
     {
-        LOG_ERROR("module", "> ServerAutoShutdown: Incorrect day in config option 'ServerAutoShutdown.EveryDays' - '{}'", day);
+        LOG_ERROR("module", "> ServerAutoShutdown: Incorrect day in config option 'ServerAutoShutdown.EveryDays' - '{}'", restartDays);
         _isEnableModule = false;
     }
-    else if (hour > 23)
+    else if (restartHour > 23)
     {
         LOG_ERROR("module", "> ServerAutoShutdown: Incorrect hour in config option 'ServerAutoShutdown.Time' - '{}'", configTime);
         _isEnableModule = false;
     }
-    else if (minute >= 60)
+    else if (restartMinute >= 60)
     {
         LOG_ERROR("module", "> ServerAutoShutdown: Incorrect minute in config option 'ServerAutoShutdown.Time' - '{}'", configTime);
         _isEnableModule = false;
     }
-    else if (second >= 60)
+    else if (restartSecond >= 60)
     {
         LOG_ERROR("module", "> ServerAutoShutdown: Incorrect second in config option 'ServerAutoShutdown.Time' - '{}'", configTime);
         _isEnableModule = false;
@@ -166,9 +167,9 @@ void ServerAutoShutdown::Init()
     {
         LOG_WARN("module", "> ServerAutoShutdown: Next time to shutdown < 10 seconds, Set next period");
         if (weekday >= 0 && weekday <= 6)
-            nextResetTime += 7 * 86400;
+            nextResetTime += WEEK;
         else
-            nextResetTime += 86400 * day;
+            nextResetTime += DAY * restartDays;
         diffToShutdown = nextResetTime - static_cast<uint32>(nowTime);
     }
 
@@ -183,11 +184,11 @@ void ServerAutoShutdown::Init()
     LOG_INFO("module", "> ServerAutoShutdown: Remaining time to shutdown - {}", Acore::Time::ToTimeString<Seconds>(diffToShutdown));
     LOG_INFO("module", " ");
 
-    uint32 preAnnounceSeconds = sConfigMgr->GetOption<uint32>("ServerAutoShutdown.PreAnnounce.Seconds", 3600);
-    if (preAnnounceSeconds > 86400)
+    uint32 preAnnounceSeconds = sConfigMgr->GetOption<uint32>("ServerAutoShutdown.PreAnnounce.Seconds", HOUR);
+    if (preAnnounceSeconds > DAY)
     {
         LOG_ERROR("module", "> ServerAutoShutdown: Ahah, how could this happen? Time to preannouce has been set to more than 1 day? ({}). Change to 1 hour (3600)", preAnnounceSeconds);
-        preAnnounceSeconds = 3600;
+        preAnnounceSeconds = HOUR;
     }
 
     uint32 timeToPreAnnounce = static_cast<uint32>(nextResetTime) - preAnnounceSeconds;


### PR DESCRIPTION
With this change, the config offers an alternative setting for enabling weekly restarts on the same recurring weekday instead of restarts every x-days. 
I made this change for myself since I wanted to have the weekly restarts/shutdowns on the same day for easier maintenance.

The original usage will still be possible if the weekday setting is kept with the default of -1 (disabled)